### PR TITLE
アジェンダ削除のリクエスト時、Timerが動いていた場合は409エラーとするよう修正

### DIFF
--- a/src/main/java/jp/co/esm/novicetimer/api/AgendaRestController.java
+++ b/src/main/java/jp/co/esm/novicetimer/api/AgendaRestController.java
@@ -155,4 +155,11 @@ public class AgendaRestController {
     @ResponseBody
     public void handleIllegalArgumentException() {
     }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler({ IllegalStateException.class })
+    @ResponseBody
+    public String handleIllegalStateException(IllegalStateException e) {
+        return e.getMessage();
+    }
 }

--- a/src/main/java/jp/co/esm/novicetimer/api/TimerRestController.java
+++ b/src/main/java/jp/co/esm/novicetimer/api/TimerRestController.java
@@ -46,5 +46,4 @@ public class TimerRestController {
         HttpStatus status = timerService.stopTimer() ? HttpStatus.OK : HttpStatus.NOT_FOUND;
         return new ResponseEntity<>(status);
     }
-
 }

--- a/src/main/java/jp/co/esm/novicetimer/service/AgendaService.java
+++ b/src/main/java/jp/co/esm/novicetimer/service/AgendaService.java
@@ -137,9 +137,12 @@ public class AgendaService {
      * @param id 削除するアジェンダ
      * @return true:削除できた場合
      * false:削除できなかった場合
+     * @throws IllegalStateException アジェンダのタイマーが作動中の場合にthrowします
      */
     public boolean deleteAgendaProcess(int id) {
-        timerService.stopTimer();
+        if(timerService.isMoving()){
+            throw new IllegalStateException("タイマーが作動中です。");
+        }
         return agendaRepository.deleteAgenda(id);
     }
 
@@ -147,9 +150,12 @@ public class AgendaService {
      * 全てのアジェンダを削除する。
      * <p>
      * 全てのアジェンダを削除する。
+     * @throws IllegalStateException アジェンダのタイマーが作動中の場合にthrowします
      */
     public void deleteAgendasProcess() {
-        timerService.stopTimer();
+        if(timerService.isMoving()){
+            throw new IllegalStateException("タイマーが作動中です。");
+        }
         agendaRepository.deleteAgendas();
     }
 

--- a/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
+++ b/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
@@ -30,6 +30,14 @@ public class TimerService {
     private Timer timer;
 
     /**
+     * Timerが作動中かを判定するメソッド
+     * @return boolean 動いていればtrueを返す。
+     */
+    public boolean isMoving(){
+        return timer != null;
+    }
+
+    /**
      * タイマーを開始するメソッド。
      * <p>
      * 与えられたSubject情報に沿った設定のタイマーを開始する。
@@ -65,10 +73,6 @@ public class TimerService {
         timer.cancel();
         timer = null;
         return true;
-    }
-
-    public boolean isMoving(){
-        return timer != null;
     }
 
     /**

--- a/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
+++ b/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
@@ -39,7 +39,7 @@ public class TimerService {
      * 既にタイマーが動いていた場合は "0" の文字列
      */
     public String startTimer(Subject subject) {
-        if (timer != null) {
+        if (isMoving()) {
             return String.valueOf(0);
         }
 
@@ -59,7 +59,7 @@ public class TimerService {
      * タイマーが動いていなかった場合はfalse<br>
      */
     public boolean stopTimer() {
-        if (timer == null) {
+        if (!isMoving()) {
             return false;
         }
         timer.cancel();
@@ -67,6 +67,9 @@ public class TimerService {
         return true;
     }
 
+    public boolean isMoving(){
+        return timer != null;
+    }
     /**
      * タイマーをThreadとして生成し、指定条件でidobataへメッセージを送信する処理を行うクラス<br>
      * TimerServiceの内部クラス

--- a/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
+++ b/src/main/java/jp/co/esm/novicetimer/service/TimerService.java
@@ -70,6 +70,7 @@ public class TimerService {
     public boolean isMoving(){
         return timer != null;
     }
+
     /**
      * タイマーをThreadとして生成し、指定条件でidobataへメッセージを送信する処理を行うクラス<br>
      * TimerServiceの内部クラス

--- a/src/test/java/jp/co/esm/novicetimer/api/AgendaRestControllerTest.java
+++ b/src/test/java/jp/co/esm/novicetimer/api/AgendaRestControllerTest.java
@@ -224,4 +224,12 @@ public class AgendaRestControllerTest {
             .andExpect(status().isOk());
     }
 
+    @Test
+    public void Timerが動いている状態でapi_agendas_idにDELETEリクエストした場合_409Conflictが返される() throws Exception {
+        doThrow(new IllegalStateException()).when(this.agendaService).deleteAgendaProcess(1);
+        mvc
+                .perform(delete("/api/agendas/1"))
+                .andExpect(status().isConflict());
+    }
+
 }

--- a/src/test/java/jp/co/esm/novicetimer/service/AgendaServiceTest.java
+++ b/src/test/java/jp/co/esm/novicetimer/service/AgendaServiceTest.java
@@ -2,14 +2,18 @@ package jp.co.esm.novicetimer.service;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import jp.co.esm.novicetimer.domain.TimerState;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -151,6 +155,9 @@ public class AgendaServiceTest {
         @Autowired
         private AgendaService agendaService;
 
+        @Mock
+        private TimerService timerService;
+
         private int setupAgendaId;
 
         @Before
@@ -172,6 +179,21 @@ public class AgendaServiceTest {
         @Test
         public void id指定でidのアジェンダがなかったときfalseが返ってくる() {
             assertThat(agendaService.deleteAgendaProcess(0), is(false));
+        }
+
+        @Test(expected = IllegalStateException.class)
+        public void Timer作動中にid指定の削除が来た場合IllegalStateExceptionが投げられる() throws Exception{
+            agendaService.changeTimerState(setupAgendaId,0, TimerStateCode.START);
+            agendaService.deleteAgendaProcess(setupAgendaId);
+        }
+
+        @After
+        public void closing(){
+            try {
+                agendaService.changeTimerState(setupAgendaId, 0, TimerStateCode.STOP);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
         }
     }
 }

--- a/src/test/java/jp/co/esm/novicetimer/service/TimerServiceTest.java
+++ b/src/test/java/jp/co/esm/novicetimer/service/TimerServiceTest.java
@@ -1,0 +1,33 @@
+package jp.co.esm.novicetimer.service;
+
+import jp.co.esm.novicetimer.domain.Agenda;
+import jp.co.esm.novicetimer.domain.Subject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TimerServiceTest {
+    @Autowired
+    TimerService timerService;
+
+    @Test
+    public void isMovingを呼ぶとTimerが動いている場合True_動いていない場合Falseであることの確認(){
+        timerService.startTimer(new Subject("test", 1, "user"));
+        assertTrue(timerService.isMoving());
+        timerService.stopTimer();
+        assertFalse(timerService.isMoving());
+    }
+}


### PR DESCRIPTION
#44  の対応
アジェンダの削除時、Timerの動作有無を判断し、実行中であれば409を返すよう修正しました。
アジェンダ及びサブジェクトの更新時の実行チェックは入れていないです。
(更新できてもいいかもな、という理由です。)